### PR TITLE
Added a new label to pr-labeler

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,3 +1,4 @@
-feature: ["feature-*", "feat-*"]
-bugfix: ["fix-*", "bugfix-*"]
-chore: ["chore-*"]
+feature: ['feature-*', 'feat-*']
+bugfix: ['fix-*', 'bugfix-*']
+chore: ['chore-*']
+skip-changelog: ['release-*']


### PR DESCRIPTION
## Descrição

Uma nova label foi adicionada com o nome skip-changelog para quando uma branch for criada com o início release-.
Com isso essa atualização não será listada no changelog do release-drafter.
