### PR TITLE
Fix: Adicionado color ao componente input

### DIFF
--- a/packages/visu/src/library/Input/style.ts
+++ b/packages/visu/src/library/Input/style.ts
@@ -2,6 +2,7 @@ import { styled } from '@/stitches.config'
 
 export const Input = styled('input', {
   backgroundColor: 'transparent',
+  color: '$gray900',
   outline: 'none !important',
 
   height: '$10',


### PR DESCRIPTION
## Componentes afetados

- Input

## Descrição

Foi adicionado a propriedade color ao componente Input.Input. A cor $gray900 foi adicionada. Agora ao configurar temas a cor do texto do input também irá mudar.
