### PR TITLE
Fix: Correção na altura do Button para não quebrar com textos grandes

### DIFF
--- a/packages/visu/src/library/Button/style.ts
+++ b/packages/visu/src/library/Button/style.ts
@@ -40,16 +40,16 @@ export const RootStyle = css({
       sm: {
         padding: '$2half $6',
         fontSize: '$sm',
-        height: '$10',
+        minHeight: '$10',
       },
       md: {
         padding: '$3 $10',
-        height: '$12',
+        minHeight: '$12',
       },
       lg: {
         padding: '$9 $12',
         fontSize: 'lg',
-        height: '$28',
+        minHeight: '$28',
 
         [`& ${Icon}`]: {
           height: '$10',


### PR DESCRIPTION
## Componentes afetados

- Button

## Descrição

No css do Button a propriedade height foi alterada para minHeight para permitir que o botão aumente de tamanho caso precise quebrar a linha do texto.
