### PR TITLE
Chore - Correções nas sugestões do tailwindcss após atualizar as configs para typescript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
   },
   "material-icon-theme.files.associations": {
     "eslint.config.cjs": "eslint"
-  }
+  },
+  "tailwindCSS.experimental.configFile": "./packages/visu/tailwind.config.ts",
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "lint-staged": "^13.1.0",
         "phosphor-react": "latest",
         "prettier": "2.8.3",
-        "prettier-plugin-tailwindcss": "^0.2.5",
+        "prettier-plugin-tailwindcss": "^0.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "turbo": "latest",
@@ -42,7 +42,7 @@
       }
     },
     "apps/docs": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@coaktion/visu": "*",
         "react": "^18.2.0",
@@ -73,7 +73,7 @@
       }
     },
     "apps/web": {
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@coaktion/visu": "*",
         "react": "^18.2.0",
@@ -25126,9 +25126,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.2.8.tgz",
-      "integrity": "sha512-KgPcEnJeIijlMjsA6WwYgRs5rh3/q76oInqtMXBA/EMcamrcYJpyhtRhyX1ayT9hnHlHTuO8sIifHF10WuSDKg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.4.1.tgz",
+      "integrity": "sha512-hwn2EiJmv8M+AW4YDkbjJ6HlZCTzLyz1QlySn9sMuKV/Px0fjwldlB7tol8GzdgqtkdPtzT3iJ4UzdnYXP25Ag==",
       "dev": true,
       "engines": {
         "node": ">=12.17.0"
@@ -25139,11 +25139,12 @@
         "@shopify/prettier-plugin-liquid": "*",
         "@shufo/prettier-plugin-blade": "*",
         "@trivago/prettier-plugin-sort-imports": "*",
-        "prettier": ">=2.2.0",
+        "prettier": "^2.2 || ^3.0",
         "prettier-plugin-astro": "*",
         "prettier-plugin-css-order": "*",
         "prettier-plugin-import-sort": "*",
         "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
         "prettier-plugin-organize-attributes": "*",
         "prettier-plugin-organize-imports": "*",
         "prettier-plugin-style-order": "*",
@@ -25176,6 +25177,9 @@
           "optional": true
         },
         "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
           "optional": true
         },
         "prettier-plugin-organize-attributes": {
@@ -29740,11 +29744,11 @@
       }
     },
     "packages/tsconfig": {
-      "version": "2.0.0"
+      "version": "2.1.0"
     },
     "packages/visu": {
       "name": "@coaktion/visu",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "tailwindcss": "^3.2.7"
       },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint-staged": "^13.1.0",
     "phosphor-react": "latest",
     "prettier": "2.8.3",
-    "prettier-plugin-tailwindcss": "^0.2.5",
+    "prettier-plugin-tailwindcss": "^0.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "turbo": "latest",


### PR DESCRIPTION
## Descrição

Correções nas sugestões do tailwindcss após atualizar as configs para typescript.
As sugestões de classes não estavam funcionando e o plugin `prettier-plugin-tailwindcss` também não.
