### PR TITLE
Chore - Correção na configuração do Eslint para monorepo

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -20,6 +20,12 @@ module.exports = {
     },
     ecmaVersion: 2020,
     sourceType: 'module',
+    tsconfigRootDir: __dirname,
+    project: [
+      './packages/visu/tsconfig.json',
+      './apps/docs/tsconfig.json',
+      './apps/web/tsconfig.json',
+    ],
   },
   plugins: ['unused-imports', 'react', 'jsx-a11y', '@typescript-eslint'],
   rules: {

--- a/packages/visu/tsconfig.json
+++ b/packages/visu/tsconfig.json
@@ -8,6 +8,6 @@
     }
   },
   "extends": "tsconfig/library.json",
-  "include": ["src"],
+  "include": ["src", "../../eslint.config.cjs"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Descrição

A formatação do Eslint com Prettier não estava funcionando. O Eslint utiliza o `@typescript-eslint/parser` e ele precisa ser configurado para especificar cada projeto do monorepo. Ao fazer as especificações na configuração do Eslint os warnings voltaram a funcionar.
