### PR TITLE
Feat visu tooltip time

### DIFF
--- a/apps/docs/src/stories/Tooltip/Time.stories.tsx
+++ b/apps/docs/src/stories/Tooltip/Time.stories.tsx
@@ -1,0 +1,140 @@
+import { Button, Tooltip, TooltipTimeProps } from '@droz-js/visu'
+import { Meta, StoryObj } from '@storybook/react'
+import { Question } from 'phosphor-react'
+
+const meta: Meta<TooltipTimeProps> = {
+  title: 'Tooltip/Time',
+  component: Tooltip.Time,
+  argTypes: {
+    children: {
+      control: 'none',
+      description: 'Trigger do Tooltip.',
+      table: {
+        type: {
+          summary: 'React.ReactNode',
+        },
+      },
+    },
+    content: {
+      control: 'text',
+      description: 'Define o conteúdo exibido no Tooltip.',
+      table: {
+        type: { summary: 'React.ReactNode' },
+      },
+      type: { name: 'string', required: false },
+    },
+    defaultOpen: {
+      control: 'boolean',
+      description: 'Define se o Tooltip deve iniciar aberto ou fechado.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+      type: { name: 'boolean', required: false },
+    },
+    closeTime: {
+      control: 'number',
+      description: 'Define o tempo em milissegundos para fechar o conteúdo do Tooltip.',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '2000' },
+      },
+      type: { name: 'number', required: false },
+    },
+    open: {
+      control: 'boolean',
+      description: 'Define se o conteúdo do Tooltip está visível ou não.',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+      type: { name: 'boolean', required: false },
+    },
+    side: {
+      control: { type: 'inline-radio' },
+      description: 'Define o local em que o componente irá aparecer, relativo ao trigger.',
+      options: ['bottom', 'left', 'right', 'top'],
+      table: {
+        type: {
+          summary: ['bottom', 'left', 'right', 'top'].join('|'),
+        },
+        defaultValue: { summary: 'bottom' },
+      },
+      type: { name: 'string', required: false },
+    },
+    onOpenChange: {
+      control: 'none',
+      description: 'Callback executado quando o estado de `open` é alterado.',
+      table: {
+        type: { summary: 'function' },
+      },
+      type: { name: 'function', required: false },
+    },
+
+    /**
+     * @deprecated - Deprecated props will be removed in the next major version.
+     */
+    text: {
+      control: 'none',
+      name: 'text (deprecated)',
+      description: '<s>Define o valor em texto do componente.</s> (deprecated) - Use a propriedade `content`.',
+      table: {
+        type: { summary: 'text' },
+      },
+      type: { name: 'string', required: false },
+    },
+  },
+  args: {
+    children: '',
+    content: 'Texto do tooltip',
+    defaultOpen: false,
+    closeTime: 2000,
+    open: false,
+    side: 'bottom',
+  },
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/cUmiZr1GhrB9HsRCuOJ0S2/%5BDroz-Nexo%5D-Library?type=design&node-id=3107-18351&t=NDiO1Vda4DCr6uFV-0',
+      allowFullscreen: true,
+    },
+  },
+}
+
+export default meta
+type TooltipTimeStory = StoryObj<TooltipTimeProps>
+
+export const ComTexto: TooltipTimeStory = {
+  name: 'Com texto',
+  render: (args) => {
+    return (
+      <Tooltip.Time {...args}>
+        <Question size={24} />
+      </Tooltip.Time>
+    )
+  },
+}
+
+export const ComReactNode: TooltipTimeStory = {
+  name: 'Com ReactNode',
+  args: {
+    content: (
+      <>
+        <p>Texto do tooltip</p>
+        <Button.Root>Button do tooltip</Button.Root>
+      </>
+    ),
+  },
+  argTypes: {
+    content: {
+      control: 'none',
+    },
+  },
+  render: (args) => {
+    return (
+      <Tooltip.Time {...args}>
+        <Question size={24} />
+      </Tooltip.Time>
+    )
+  },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
     },
     "apps/docs": {
       "name": "@droz-js/visu-docs",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@droz-js/visu": "*",
         "react": "^18.2.0",
@@ -75,7 +75,7 @@
     },
     "apps/web": {
       "name": "@droz-js/visu-web",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@droz-js/visu": "*",
         "react": "^18.2.0",
@@ -30188,11 +30188,11 @@
     },
     "packages/tsconfig": {
       "name": "@droz-js/tsconfig",
-      "version": "2.4.0"
+      "version": "2.5.0"
     },
     "packages/visu": {
       "name": "@droz-js/visu",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-avatar": "^1.0.2",

--- a/packages/visu/src/App.tsx
+++ b/packages/visu/src/App.tsx
@@ -33,21 +33,9 @@ function App() {
       <form onSubmit={handleSubmit(onSubmit)}>
         {/* ================================= TEST AREA ================================= */}
         <Tooltip.Time content="Copiado!" closeTime={2000} side="top">
-          <span>Times</span>
+          <span>Time</span>
         </Tooltip.Time>
-        <Tooltip.Close
-          content="eargfv erget grt hbertybwrt vwer cwqa dcew cerfv wertb wrterybhne rgbhqwe v erv rsb wsertb ertvb srtb
-            hntryehn ryhb wsertv erv"
-          side="top"
-        >
-          <span>Close</span>
-        </Tooltip.Close>
-        <Tooltip.Hover content="Copiado!" side="top">
-          <span>Hover</span>
-        </Tooltip.Hover>
-        <Tooltip.Step side="top">
-          <span>Step</span>
-        </Tooltip.Step>
+
         {/* ================================= TEST AREA ================================= */}
       </form>
     </LayoutDefault>

--- a/packages/visu/src/App.tsx
+++ b/packages/visu/src/App.tsx
@@ -1,5 +1,5 @@
 import LayoutDefault from './layout/Default'
-import { Skeleton } from './library'
+import { Tooltip } from './library'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Eraser } from 'phosphor-react'
 import { useState } from 'react'
@@ -32,10 +32,22 @@ function App() {
     <LayoutDefault asChild terminal={[watch(), test]} buttons={[{ icon: <Eraser />, onClick: clearState }]}>
       <form onSubmit={handleSubmit(onSubmit)}>
         {/* ================================= TEST AREA ================================= */}
-        <div className="flex h-full w-full flex-col gap-4 ">
-          <Skeleton className="h-32 w-full" repeat={4} />
-        </div>
-
+        <Tooltip.Time content="Copiado!" closeTime={2000} side="top">
+          <span>Times</span>
+        </Tooltip.Time>
+        <Tooltip.Close
+          content="eargfv erget grt hbertybwrt vwer cwqa dcew cerfv wertb wrterybhne rgbhqwe v erv rsb wsertb ertvb srtb
+            hntryehn ryhb wsertv erv"
+          side="top"
+        >
+          <span>Close</span>
+        </Tooltip.Close>
+        <Tooltip.Hover content="Copiado!" side="top">
+          <span>Hover</span>
+        </Tooltip.Hover>
+        <Tooltip.Step side="top">
+          <span>Step</span>
+        </Tooltip.Step>
         {/* ================================= TEST AREA ================================= */}
       </form>
     </LayoutDefault>

--- a/packages/visu/src/__tests__/Tooltip/Time.test.tsx
+++ b/packages/visu/src/__tests__/Tooltip/Time.test.tsx
@@ -1,13 +1,12 @@
 import { Tooltip } from '@library'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
-// Testes limitados por conta do Radix
-describe('TooltipClose tests', () => {
-  it('Should render a TooltipClose element', () => {
+describe('TooltipTime tests', () => {
+  it('Should render a TooltipTime element', () => {
     render(
-      <Tooltip.Close content="Close">
+      <Tooltip.Time duration={5000} content="Time">
         <div data-testid="element">Hello</div>
-      </Tooltip.Close>,
+      </Tooltip.Time>,
     )
     const element = screen.getByTestId('element')
 
@@ -16,9 +15,9 @@ describe('TooltipClose tests', () => {
 
   it('Should render a text with the prop "content"', async () => {
     render(
-      <Tooltip.Close content="Text1">
+      <Tooltip.Time duration={5000} content="Text1">
         <div data-testid="element">Hello</div>
-      </Tooltip.Close>,
+      </Tooltip.Time>,
     )
     const element = screen.getByTestId('element')
     fireEvent.click(element)
@@ -30,9 +29,9 @@ describe('TooltipClose tests', () => {
 
   it('Should render a ReactNode content with the prop "content"', async () => {
     render(
-      <Tooltip.Close content={<span data-testid="content">Text1</span>}>
+      <Tooltip.Time duration={5000} content={<span data-testid="content">Text1</span>}>
         <div data-testid="element">Hello</div>
-      </Tooltip.Close>,
+      </Tooltip.Time>,
     )
     const element = screen.getByTestId('element')
     fireEvent.click(element)
@@ -42,20 +41,22 @@ describe('TooltipClose tests', () => {
     })
   })
 
-  /**
-   * @deprecated - Teste para uma propriedade deprecated
-   */
-  it('Should render a text with the prop "text"', async () => {
+  it('Should keep the TooltipTime open for the specified duration', async () => {
+    jest.useFakeTimers()
+
     render(
-      <Tooltip.Close text="Text1">
+      <Tooltip.Time duration={5000} content="Time">
         <div data-testid="element">Hello</div>
-      </Tooltip.Close>,
+      </Tooltip.Time>,
     )
+
     const element = screen.getByTestId('element')
     fireEvent.click(element)
 
+    jest.advanceTimersByTime(5000)
+
     await waitFor(() => {
-      expect(screen.getByRole('dialog')).toHaveTextContent('Text1')
+      expect(screen.queryByRole('dialog')).toBeNull()
     })
   })
 })

--- a/packages/visu/src/__tests__/Tooltip/Time.test.tsx
+++ b/packages/visu/src/__tests__/Tooltip/Time.test.tsx
@@ -1,10 +1,12 @@
 import { Tooltip } from '@library'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
+// Testes limitados por conta do Radix
 describe('TooltipTime tests', () => {
   it('Should render a TooltipTime element', () => {
     render(
-      <Tooltip.Time duration={5000} content="Time">
+      <Tooltip.Time content="Text1">
         <div data-testid="element">Hello</div>
       </Tooltip.Time>,
     )
@@ -14,49 +16,104 @@ describe('TooltipTime tests', () => {
   })
 
   it('Should render a text with the prop "content"', async () => {
+    const user = userEvent.setup()
+
     render(
-      <Tooltip.Time duration={5000} content="Text1">
+      <Tooltip.Time content="Text1">
         <div data-testid="element">Hello</div>
       </Tooltip.Time>,
     )
     const element = screen.getByTestId('element')
-    fireEvent.click(element)
+    await user.click(element)
 
     await waitFor(() => {
-      expect(screen.getByRole('dialog')).toHaveTextContent('Text1')
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Text1')
     })
   })
 
   it('Should render a ReactNode content with the prop "content"', async () => {
+    const user = userEvent.setup()
+
     render(
-      <Tooltip.Time duration={5000} content={<span data-testid="content">Text1</span>}>
+      <Tooltip.Time content={<span data-testid="content">Text1</span>}>
         <div data-testid="element">Hello</div>
       </Tooltip.Time>,
     )
     const element = screen.getByTestId('element')
-    fireEvent.click(element)
+    await user.click(element)
 
     await waitFor(() => {
-      expect(screen.getByRole('dialog')).toContainHTML('<span data-testid="content">Text1</span>')
+      expect(screen.getByRole('tooltip')).toContainHTML('<span data-testid="content">Text1</span>')
     })
   })
 
-  it('Should keep the TooltipTime open for the specified duration', async () => {
-    jest.useFakeTimers()
-
+  it('Should render content when trigger gets a click', async () => {
     render(
-      <Tooltip.Time duration={5000} content="Time">
+      <Tooltip.Time content={<span data-testid="content">Text1</span>}>
         <div data-testid="element">Hello</div>
       </Tooltip.Time>,
     )
-
     const element = screen.getByTestId('element')
     fireEvent.click(element)
 
-    jest.advanceTimersByTime(5000)
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toContainHTML('<span data-testid="content">Text1</span>')
+    })
+  })
+
+  it('Should execute "onOpenChange" when "open" value changes', async () => {
+    const onOpenChange = jest.fn()
+    console.log(onOpenChange)
+    render(
+      <Tooltip.Time content={<span data-testid="content">Text1</span>} onOpenChange={onOpenChange}>
+        <div data-testid="element">Hello</div>
+      </Tooltip.Time>,
+    )
+    const element = screen.getByTestId('element')
+    fireEvent.click(element)
 
     await waitFor(() => {
-      expect(screen.queryByRole('dialog')).toBeNull()
+      expect(screen.getByRole('tooltip')).toContainHTML('<span data-testid="content">Text1</span>')
+      expect(onOpenChange).toBeCalledTimes(1)
+      expect(onOpenChange).toBeCalledWith(true)
+    })
+  })
+
+  /**
+   * @deprecated - Teste para uma propriedade deprecated
+   */
+  it('Should render a text with the prop "text"', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <Tooltip.Time text="Text1">
+        <div data-testid="element">Hello</div>
+      </Tooltip.Time>,
+    )
+    const element = screen.getByTestId('element')
+    await user.click(element)
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Text1')
+    })
+  })
+
+  it('Should close the tooltip after the specified closeTime', async () => {
+    const closeTime = 3500 // Tempo de fechamento em milissegundos
+
+    render(
+      <Tooltip.Time content={<span data-testid="content">Text1</span>} closeTime={closeTime}>
+        <div data-testid="element">Hello</div>
+      </Tooltip.Time>,
+    )
+    const element = screen.getByTestId('element')
+    fireEvent.click(element)
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toContainHTML('<span data-testid="content">Text1</span>')
+      setTimeout(() => {
+        expect(screen.queryByRole('tooltip')).toBeNull()
+      }, closeTime + 100)
     })
   })
 })

--- a/packages/visu/src/library/Tooltip/Hover.tsx
+++ b/packages/visu/src/library/Tooltip/Hover.tsx
@@ -1,17 +1,9 @@
 import * as RadixTooltip from '@radix-ui/react-tooltip'
 import { Position } from '@types'
 import { clsx } from 'clsx'
-import {
-  FC,
-  HTMLAttributes,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react'
+import { FC, HTMLAttributes, ReactNode, useCallback, useEffect, useState } from 'react'
 
-export interface TooltipHoverProps
-  extends Omit<HTMLAttributes<HTMLSpanElement>, 'content'> {
+export interface TooltipHoverProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'content'> {
   // Optional because we can't remove `text` until the next major release
   content?: ReactNode
   defaultOpen?: boolean
@@ -60,11 +52,7 @@ const TooltipHover: FC<TooltipHoverProps> = ({
         open={tooltipOpen}
         onOpenChange={(value) => handleOpenChange(value)}
       >
-        <RadixTooltip.Trigger
-          className="z-10"
-          asChild
-          onClick={() => handleOpenChange(true)}
-        >
+        <RadixTooltip.Trigger className="z-10" asChild onClick={() => handleOpenChange(true)}>
           {children}
         </RadixTooltip.Trigger>
         <RadixTooltip.Portal>

--- a/packages/visu/src/library/Tooltip/Time.tsx
+++ b/packages/visu/src/library/Tooltip/Time.tsx
@@ -1,44 +1,79 @@
-import * as RadixPopover from '@radix-ui/react-popover'
+import * as RadixTooltip from '@radix-ui/react-tooltip'
 import { Position } from '@types'
 import { clsx } from 'clsx'
-import { FC, HTMLAttributes, ReactNode, useEffect, useState } from 'react'
+import { FC, HTMLAttributes, ReactNode, useCallback, useEffect, useState } from 'react'
 
 export interface TooltipTimeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'content'> {
+  // Optional because we can't remove `text` until the next major release
   content?: ReactNode
-  duration: number
+  defaultOpen?: boolean
+  open?: boolean
   side?: Position
+  closeTime?: number
+
+  onOpenChange?: (open: boolean) => void
+  /**
+   * @deprecated Use `content` instead. Will be removed in the next major release
+   */
+  text?: string
 }
 
-const TooltipTime: FC<TooltipTimeProps> = ({ children, className, content, duration, side, ...rest }) => {
-  const [open, setOpen] = useState(false)
+const TooltipTime: FC<TooltipTimeProps> = ({
+  children,
+  className,
+  content,
+  defaultOpen = false,
+  open = false,
+  onOpenChange,
+  closeTime,
+  side,
+  text,
+  ...rest
+}) => {
+  const [tooltipOpen, setTooltipOpen] = useState(open)
+
+  const handleOpenChange = useCallback(
+    (value: boolean) => {
+      setTooltipOpen(value)
+      if (onOpenChange) onOpenChange(value)
+
+      if (value && closeTime) {
+        setTimeout(() => {
+          setTooltipOpen(false)
+          if (onOpenChange) onOpenChange(false)
+        }, closeTime)
+      }
+    },
+    [onOpenChange, closeTime],
+  )
 
   useEffect(() => {
-    setOpen(true)
+    setTooltipOpen(open)
+  }, [open])
 
-    const timeoutId = setTimeout(() => {
-      setOpen(false)
-    }, duration)
-
-    return () => {
-      clearTimeout(timeoutId)
-    }
-  }, [duration])
+  const handleTooltipClick = () => {
+    handleOpenChange(!tooltipOpen)
+  }
 
   return (
-    <RadixPopover.Root open={open}>
-      <RadixPopover.Trigger asChild>{children}</RadixPopover.Trigger>
-      <RadixPopover.Portal>
-        <RadixPopover.Content
-          side={side}
-          sideOffset={16}
-          className="flex max-w-xs items-center gap-4 rounded-md bg-gray-100 p-6 shadow-sm"
-          {...rest}
-        >
-          <span className={clsx([className, 'flex-1 text-sm'])}>{content}</span>
-          <RadixPopover.Arrow className="h-2 w-5 fill-gray-100" />
-        </RadixPopover.Content>
-      </RadixPopover.Portal>
-    </RadixPopover.Root>
+    <RadixTooltip.Provider>
+      <RadixTooltip.Root defaultOpen={defaultOpen} open={tooltipOpen}>
+        <RadixTooltip.Trigger className="z-10" asChild onClick={handleTooltipClick}>
+          {children}
+        </RadixTooltip.Trigger>
+
+        <RadixTooltip.Portal>
+          <RadixTooltip.Content side={side} sideOffset={5}>
+            <RadixTooltip.Arrow className="h-2 w-5 fill-background" />
+            <div className="max-w-xs rounded-md border-none bg-background p-3 shadow-sm">
+              <span className={clsx([className, 'text-sm'])} {...rest}>
+                {content || text}
+              </span>
+            </div>
+          </RadixTooltip.Content>
+        </RadixTooltip.Portal>
+      </RadixTooltip.Root>
+    </RadixTooltip.Provider>
   )
 }
 

--- a/packages/visu/src/library/Tooltip/Time.tsx
+++ b/packages/visu/src/library/Tooltip/Time.tsx
@@ -10,7 +10,6 @@ export interface TooltipTimeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 
   open?: boolean
   side?: Position
   closeTime?: number
-
   onOpenChange?: (open: boolean) => void
   /**
    * @deprecated Use `content` instead. Will be removed in the next major release
@@ -23,9 +22,9 @@ const TooltipTime: FC<TooltipTimeProps> = ({
   className,
   content,
   defaultOpen = false,
+  closeTime = 2000,
   open = false,
   onOpenChange,
-  closeTime,
   side,
   text,
   ...rest

--- a/packages/visu/src/library/Tooltip/Time.tsx
+++ b/packages/visu/src/library/Tooltip/Time.tsx
@@ -1,0 +1,47 @@
+import * as RadixPopover from '@radix-ui/react-popover'
+import { Position } from '@types'
+import { clsx } from 'clsx'
+import { FC, HTMLAttributes, ReactNode, useEffect, useState } from 'react'
+
+export interface TooltipTimeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'content'> {
+  content?: ReactNode
+  duration: number
+  side?: Position
+}
+
+const TooltipTime: FC<TooltipTimeProps> = ({ children, className, content, duration, side, ...rest }) => {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    setOpen(true)
+
+    const timeoutId = setTimeout(() => {
+      setOpen(false)
+    }, duration)
+
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [duration])
+
+  return (
+    <RadixPopover.Root open={open}>
+      <RadixPopover.Trigger asChild>{children}</RadixPopover.Trigger>
+      <RadixPopover.Portal>
+        <RadixPopover.Content
+          side={side}
+          sideOffset={16}
+          className="flex max-w-xs items-center gap-4 rounded-md bg-gray-100 p-6 shadow-sm"
+          {...rest}
+        >
+          <span className={clsx([className, 'flex-1 text-sm'])}>{content}</span>
+          <RadixPopover.Arrow className="h-2 w-5 fill-gray-100" />
+        </RadixPopover.Content>
+      </RadixPopover.Portal>
+    </RadixPopover.Root>
+  )
+}
+
+TooltipTime.displayName = 'Tooltip.Time'
+
+export default TooltipTime

--- a/packages/visu/src/library/Tooltip/index.ts
+++ b/packages/visu/src/library/Tooltip/index.ts
@@ -1,15 +1,18 @@
 import TooltipClose from './Close'
 import TooltipHover from './Hover'
 import TooltipStep from './Step'
+import TooltipTime from './Time'
 
 export type { TooltipCloseProps } from './Close'
 export type { TooltipHoverProps } from './Hover'
 export type { TooltipStepProps } from './Step'
+export type { TooltipTimeProps } from './Time'
 
 const Tooltip = {
   Close: TooltipClose,
   Hover: TooltipHover,
   Step: TooltipStep,
+  Time: TooltipTime,
 }
 
 export default Tooltip


### PR DESCRIPTION
## 📝 Description

Criada nova variação do tooltip de nome "time"

## 🚀 Behavior Changes

- O trigger de abertura foi alterado para abrir ao clicar sobre o conteúdo
- Foi adicionado um tempo de fechamento automático do tooltip em 2s (parâmetro variável) após a abertura via trigger (parâmetor closeTime{})

## 💣 Is this a breaking change (Yes/No):

Não

## 📝 Additional Information