### PR TITLE
Adjust collapsed sidebar component to show Avatar component

### DIFF
--- a/package/src/App.tsx
+++ b/package/src/App.tsx
@@ -1,11 +1,10 @@
 import LayoutDefault from './layout/Default'
-
-import { Select } from './library'
+import Avatar from './library/Avatar'
+import Sidebar from './library/Sidebar'
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Eraser } from 'phosphor-react'
-import { SetStateAction, useState } from 'react'
-
+import { Eraser } from '@phosphor-icons/react'
+import { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { z } from 'zod'
 
@@ -39,11 +38,10 @@ function App() {
     setTest([])
   }
 
-  const [selectedValue, setSelectedValue] = useState('')
+  // =====
+  const [isSidebarExpanded, setIsSidebarExpanded] = useState(false)
 
-  const handleChange = (value: SetStateAction<string>) => {
-    setSelectedValue(value)
-  }
+  // =====
 
   return (
     <LayoutDefault
@@ -54,32 +52,43 @@ function App() {
       <form onSubmit={handleSubmit(onSubmit)}>
         {/* ================================= TEST AREA ================================= */}
 
-        <Select.Root
-          value={selectedValue}
-          onChange={handleChange}
-          placeholder="Selecione uma opção"
-          enableSearch={true}
-          searchPlaceholder="Digite aqui sua busca"
+        <Sidebar.Root
+          className="px-0"
+          expanded={isSidebarExpanded}
+          setExpanded={() => setIsSidebarExpanded(!isSidebarExpanded)}
         >
-          <Select.Item value="option1">Alice</Select.Item>
-          <Select.Item value="option2">Bob</Select.Item>
-          <Select.Item value="option3">Charlie</Select.Item>
-          <Select.Item value="option4">David</Select.Item>
-          <Select.Item value="option5">Emma</Select.Item>
-          <Select.Item value="option6">Frank</Select.Item>
-          <Select.Item value="option7">Grace</Select.Item>
-          <Select.Item value="option8">Harry</Select.Item>
-          <Select.Item value="option9">Ivy</Select.Item>
-          <Select.Item value="option10">Jack</Select.Item>
-          <Select.Item value="option11">Kate</Select.Item>
-          <Select.Item value="option12">Liam</Select.Item>
-          <Select.Item value="option13">Mia</Select.Item>
-          <Select.Item value="option14">Noah</Select.Item>
-          <Select.Item value="option15">Olivia</Select.Item>
-          <Select.Item value="option16">Peter</Select.Item>
-          <Select.Item value="option17">Quinn</Select.Item>
-        </Select.Root>
-
+          <Sidebar.Header>
+            <a key={'g'} href={'/'}>
+              LINK-1
+            </a>
+          </Sidebar.Header>
+          <Sidebar.Body>
+            <div className="flex flex-col gap-2">
+              <Sidebar.Button
+                icon={
+                  <Avatar
+                    className="mx-auto [&>svg]:h-6 [&>svg]:w-6"
+                    size="sm"
+                    fallback="JT"
+                    alt="Avatar"
+                  />
+                }
+                text="John Textor"
+              />
+              <Sidebar.Button
+                icon={
+                  <Avatar
+                    className="mx-auto [&>svg]:h-6 [&>svg]:w-6"
+                    size="sm"
+                    fallback="CM"
+                    alt="Avatar"
+                  />
+                }
+                text="Charles Midway"
+              />
+            </div>
+          </Sidebar.Body>
+        </Sidebar.Root>
 
         {/* ================================= TEST AREA ================================= */}
       </form>

--- a/package/src/library/Select/Root.tsx
+++ b/package/src/library/Select/Root.tsx
@@ -5,10 +5,7 @@ import { Status, StatusClass } from '@types'
 
 import { CaretDown, CaretUp } from '@phosphor-icons/react'
 import * as RadixSelect from '@radix-ui/react-select'
-
-import { CaretDown, CaretUp } from 'phosphor-react'
 import { FC, useState, Children, isValidElement, SetStateAction } from 'react'
-
 
 const statusVariants: StatusClass = {
   error: { root: 'border-error' },

--- a/package/src/library/Select/Search.tsx
+++ b/package/src/library/Select/Search.tsx
@@ -1,5 +1,5 @@
+import { MagnifyingGlass } from '@phosphor-icons/react'
 import * as RadixSelect from '@radix-ui/react-select'
-import { MagnifyingGlass } from 'phosphor-react'
 import { FC, useState, ChangeEvent } from 'react'
 
 export interface SearchInputProps {

--- a/package/src/library/Sidebar/Body.tsx
+++ b/package/src/library/Sidebar/Body.tsx
@@ -12,7 +12,7 @@ const SidebarBody: FC<SidebarBodyProps> = ({
   return (
     <div
       className={cn(
-        'flex h-full w-full flex-col justify-between gap-2 py-4',
+        'flex h-full w-full flex-col justify-between gap-2 px-2 py-4',
         className,
       )}
       {...rest}

--- a/package/src/library/Sidebar/Button.tsx
+++ b/package/src/library/Sidebar/Button.tsx
@@ -18,15 +18,17 @@ const SidebarButton: FC<SidebarButtonProps> = ({
   return (
     <button
       className={cn(
-        'flex w-full flex-row items-center gap-2 rounded-lg px-2 py-2 transition-colors hover:bg-primary hover:text-gray-100 [&:hover_svg]:text-gray-100 [&_svg]:text-primary',
+        'flex w-auto flex-row items-center  rounded-lg px-2 py-2 transition-colors hover:bg-primary hover:text-gray-100 [&:hover_svg]:text-gray-100 [&_svg]:text-primary',
         className,
       )}
       {...rest}
     >
       <Tooltip.Hover content={text} side="right">
-        <div className="mx-auto [&>svg]:h-6 [&>svg]:w-6">{icon}</div>
+        <div className="mx-auto inline-table [&>svg]:h-6 [&>svg]:w-6">
+          {icon}
+        </div>
       </Tooltip.Hover>
-      <span className="flex-1 text-left text-sm">{text}</span>
+      <span className="flex-1 pl-2 text-left text-sm">{text}</span>
     </button>
   )
 }

--- a/package/src/library/Sidebar/Root.tsx
+++ b/package/src/library/Sidebar/Root.tsx
@@ -19,7 +19,7 @@ const SidebarRoot: FC<SidebarRootProps> = ({
     <aside
       className={cn(
         'sticky top-0 flex h-screen flex-col justify-between border-r border-gray-300 transition-all duration-300 [&_*]:overflow-hidden [&_*]:text-ellipsis [&_*]:whitespace-nowrap',
-        expanded ? 'w-56 px-4' : 'w-14 px-2 [&_span]:hidden',
+        expanded ? 'w-56 px-4' : '[[&_span]:not(img)]:hidden w-14 pl-2',
         className,
       )}
       {...rest}


### PR DESCRIPTION
## 📝 Description
CU-86drv9t7v
- Adjust collapsed sidebar component to show Avatar component

## 🚀 Why is this change required and behavior changes
- Sidebar component, collapsed, did not show the avatar component internally
- The problem was in the logic of hiding sidebar children

## 💣 Is this a breaking change:
- [ ] Yes
- [X] No

## 📝 Additional Information

## Checklist
- [X] I've created/modified some component
- [ ] I've created/modified the component's stories
- [ ] I've created/modified the component's tests
