### PR TITLE
Bug - Adjust css side spacing in collapsed sidebar

### DIFF
--- a/package/src/library/Sidebar/Body.tsx
+++ b/package/src/library/Sidebar/Body.tsx
@@ -12,7 +12,7 @@ const SidebarBody: FC<SidebarBodyProps> = ({
   return (
     <div
       className={cn(
-        'flex h-full w-full flex-col justify-between gap-2 px-2 py-4',
+        'flex h-full w-full flex-col justify-between gap-2 py-4',
         className,
       )}
       {...rest}

--- a/package/src/library/Sidebar/Button.tsx
+++ b/package/src/library/Sidebar/Button.tsx
@@ -18,7 +18,7 @@ const SidebarButton: FC<SidebarButtonProps> = ({
   return (
     <button
       className={cn(
-        'flex w-auto flex-row items-center  rounded-lg px-2 py-2 transition-colors hover:bg-primary hover:text-gray-100 [&:hover_svg]:text-gray-100 [&_svg]:text-primary',
+        'flex w-full flex-row items-center  rounded-lg px-2 py-2 transition-colors hover:bg-primary hover:text-gray-100 [&:hover_svg]:text-gray-100 [&_svg]:text-primary',
         className,
       )}
       {...rest}

--- a/package/src/library/Sidebar/Root.tsx
+++ b/package/src/library/Sidebar/Root.tsx
@@ -19,7 +19,7 @@ const SidebarRoot: FC<SidebarRootProps> = ({
     <aside
       className={cn(
         'sticky top-0 flex h-screen flex-col justify-between border-r border-gray-300 transition-all duration-300 [&_*]:overflow-hidden [&_*]:text-ellipsis [&_*]:whitespace-nowrap',
-        expanded ? 'w-56 px-4' : '[[&_span]:not(img)]:hidden w-14 pl-2',
+        expanded ? 'w-56 px-4' : '[[&_span]:not(img)]:hidden w-14 px-2',
         className,
       )}
       {...rest}


### PR DESCRIPTION
CU-86dt0fjx0

## 📝 Description
- Adjust css side spacing in collapsed sidebar

## 🚀 Why is this change required and behavior changes
- Side bar update error caused lateral displacement of link buttons

## 💣 Is this a breaking change:
- [  ] Yes
- [X] No

## Checklist
- [X] I've created/modified some component
- [ ] I've created/modified the component's stories
- [ ] I've created/modified the component's tests
