### PR TITLE
Update DatePicker Component Width Based on Internal Popover

### DIFF
--- a/package/src/App.tsx
+++ b/package/src/App.tsx
@@ -57,6 +57,8 @@ function App() {
         {/* ================================= TEST AREA ================================= */}
         <div className="w-full">
           <DatePicker
+            className="w-full"
+            align="center"
             placeholder="Selecione uma data"
             icon={<CalendarIcon />}
             mode="multiple"

--- a/package/src/App.tsx
+++ b/package/src/App.tsx
@@ -60,6 +60,7 @@ const App = () => {
         {/* ================================= TEST AREA ================================= */}
 
         <DatePicker
+          className="w-1/2"
           placeholder="Selecione uma data"
           icon={<CalendarIcon />}
           mode="multiple"

--- a/package/src/App.tsx
+++ b/package/src/App.tsx
@@ -60,7 +60,7 @@ const App = () => {
         {/* ================================= TEST AREA ================================= */}
 
         <DatePicker
-          className="w-1/2"
+          width="w-full"
           placeholder="Selecione uma data"
           icon={<CalendarIcon />}
           mode="multiple"

--- a/package/src/App.tsx
+++ b/package/src/App.tsx
@@ -1,8 +1,8 @@
 import LayoutDefault from './layout/Default'
-import { Button, DateRange, Drawer, Form, Icon } from './library'
+import { Form, DatePicker } from './library'
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Eraser, X } from '@phosphor-icons/react'
+import { Eraser, Calendar as CalendarIcon } from '@phosphor-icons/react'
 import { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { z } from 'zod'
@@ -13,6 +13,10 @@ const formSchema = z.object({
 
 type FormSchemaProps = z.infer<typeof formSchema>
 
+type DateRange = {
+  from: Date | undefined
+  to?: Date | undefined
+}
 function App() {
   const [test, setTest] = useState<DateRange>()
   const {
@@ -43,8 +47,6 @@ function App() {
     }
   }
 
-  console.log(selectedDates)
-
   return (
     <LayoutDefault
       asChild
@@ -53,21 +55,19 @@ function App() {
     >
       <Form.Root onSubmit={handleSubmit(onSubmit)}>
         {/* ================================= TEST AREA ================================= */}
-
-
-        <DatePicker
-          placeholder="Selecione uma data"
-          icon={<CalendarIcon />}
-          mode="multiple"
-          options={{
-            weekday: 'long',
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          }}
-        />
-
-
+        <div className="w-full">
+          <DatePicker
+            placeholder="Selecione uma data"
+            icon={<CalendarIcon />}
+            mode="multiple"
+            options={{
+              weekday: 'long',
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            }}
+          />
+        </div>
         {/* ================================= TEST AREA ================================= */}
       </Form.Root>
     </LayoutDefault>

--- a/package/src/library/DatePicker/index.tsx
+++ b/package/src/library/DatePicker/index.tsx
@@ -8,6 +8,7 @@ type DatePickerProps = CalendarProps & {
   placeholder?: string
   icon?: InputIconProps['icon']
   options?: Intl.DateTimeFormatOptions
+  width?: '' | 'w-full'
 }
 
 export const formatDate = (
@@ -25,7 +26,7 @@ const DatePicker = ({
   placeholder,
   icon,
   options,
-
+  width = '',
   ...rest
 }: DatePickerProps) => {
   const formatDates = (dates: Date[]) => {
@@ -58,24 +59,22 @@ const DatePicker = ({
   }
 
   return (
-    <div>
-      <Popover.Root>
-        <Popover.Trigger className="w-full">
-          <Input.Root className="mb-2">
-            <Input.Input
-              type="text"
-              placeholder={placeholder}
-              value={getInputValue(rest.selected)}
-              readOnly
-            />
-            <Input.Icon icon={icon} />
-          </Input.Root>
-        </Popover.Trigger>
-        <Popover.Content>
-          <Calendar {...rest} className="shadow-lg" />
-        </Popover.Content>
-      </Popover.Root>
-    </div>
+    <Popover.Root>
+      <Popover.Trigger className={width}>
+        <Input.Root className="mb-2">
+          <Input.Input
+            type="text"
+            placeholder={placeholder}
+            value={getInputValue(rest.selected)}
+            readOnly
+          />
+          <Input.Icon icon={icon} />
+        </Input.Root>
+      </Popover.Trigger>
+      <Popover.Content>
+        <Calendar {...rest} className="shadow-lg" />
+      </Popover.Content>
+    </Popover.Root>
   )
 }
 

--- a/package/src/library/DatePicker/index.tsx
+++ b/package/src/library/DatePicker/index.tsx
@@ -8,6 +8,8 @@ type DatePickerProps = CalendarProps & {
   placeholder?: string
   icon?: InputIconProps['icon']
   options?: Intl.DateTimeFormatOptions
+  className?: string
+  align?: 'center' | 'start' | 'end' | undefined
 }
 
 export const formatDate = (
@@ -25,6 +27,8 @@ const DatePicker = ({
   placeholder,
   icon,
   options,
+  className,
+  align,
   ...rest
 }: DatePickerProps) => {
   const formatDates = (dates: Date[]) => {
@@ -58,7 +62,7 @@ const DatePicker = ({
 
   return (
     <Popover.Root>
-      <Popover.Trigger className="w-full">
+      <Popover.Trigger className={className}>
         <Input.Root className="mb-2">
           <Input.Input
             type="text"
@@ -69,8 +73,8 @@ const DatePicker = ({
           <Input.Icon icon={icon} />
         </Input.Root>
       </Popover.Trigger>
-      <Popover.Content autoSize={true}>
-        <Calendar {...rest} className="shadow-lg" />
+      <Popover.Content align={align}>
+        <Calendar className="shadow-lg" />
       </Popover.Content>
     </Popover.Root>
   )

--- a/package/src/library/DatePicker/index.tsx
+++ b/package/src/library/DatePicker/index.tsx
@@ -8,7 +8,6 @@ type DatePickerProps = CalendarProps & {
   placeholder?: string
   icon?: InputIconProps['icon']
   options?: Intl.DateTimeFormatOptions
-  width?: '' | 'w-full'
 }
 
 export const formatDate = (
@@ -26,7 +25,6 @@ const DatePicker = ({
   placeholder,
   icon,
   options,
-  width = '',
   ...rest
 }: DatePickerProps) => {
   const formatDates = (dates: Date[]) => {
@@ -60,7 +58,7 @@ const DatePicker = ({
 
   return (
     <Popover.Root>
-      <Popover.Trigger className={width}>
+      <Popover.Trigger className="w-full">
         <Input.Root className="mb-2">
           <Input.Input
             type="text"
@@ -71,7 +69,7 @@ const DatePicker = ({
           <Input.Icon icon={icon} />
         </Input.Root>
       </Popover.Trigger>
-      <Popover.Content>
+      <Popover.Content autoSize={true}>
         <Calendar {...rest} className="shadow-lg" />
       </Popover.Content>
     </Popover.Root>

--- a/package/src/library/DatePicker/index.tsx
+++ b/package/src/library/DatePicker/index.tsx
@@ -58,24 +58,22 @@ const DatePicker = ({
   }
 
   return (
-    <div className="relative">
-      <Popover.Root>
-        <Popover.Trigger>
-          <Input.Root className="mb-2">
-            <Input.Input
-              type="text"
-              placeholder={placeholder}
-              value={getInputValue(rest.selected)}
-              readOnly
-            />
-            <Input.Icon icon={icon} />
-          </Input.Root>
-        </Popover.Trigger>
-        <Popover.Content>
-          <Calendar {...rest} className="shadow-lg" />
-        </Popover.Content>
-      </Popover.Root>
-    </div>
+    <Popover.Root>
+      <Popover.Trigger className="w-full">
+        <Input.Root className="mb-2">
+          <Input.Input
+            type="text"
+            placeholder={placeholder}
+            value={getInputValue(rest.selected)}
+            readOnly
+          />
+          <Input.Icon icon={icon} />
+        </Input.Root>
+      </Popover.Trigger>
+      <Popover.Content>
+        <Calendar {...rest} className="shadow-lg" />
+      </Popover.Content>
+    </Popover.Root>
   )
 }
 

--- a/package/src/library/DatePicker/index.tsx
+++ b/package/src/library/DatePicker/index.tsx
@@ -58,22 +58,24 @@ const DatePicker = ({
   }
 
   return (
-    <Popover.Root>
-      <Popover.Trigger className="w-full">
-        <Input.Root className="mb-2">
-          <Input.Input
-            type="text"
-            placeholder={placeholder}
-            value={getInputValue(rest.selected)}
-            readOnly
-          />
-          <Input.Icon icon={icon} />
-        </Input.Root>
-      </Popover.Trigger>
-      <Popover.Content>
-        <Calendar {...rest} className="shadow-lg" />
-      </Popover.Content>
-    </Popover.Root>
+    <div>
+      <Popover.Root>
+        <Popover.Trigger className="w-full">
+          <Input.Root className="mb-2">
+            <Input.Input
+              type="text"
+              placeholder={placeholder}
+              value={getInputValue(rest.selected)}
+              readOnly
+            />
+            <Input.Icon icon={icon} />
+          </Input.Root>
+        </Popover.Trigger>
+        <Popover.Content>
+          <Calendar {...rest} className="shadow-lg" />
+        </Popover.Content>
+      </Popover.Root>
+    </div>
   )
 }
 

--- a/package/src/library/Popover/Content.tsx
+++ b/package/src/library/Popover/Content.tsx
@@ -3,20 +3,28 @@ import { cn } from '@/src/utils/class-merge.helper'
 import * as RadixPopover from '@radix-ui/react-popover'
 import { FC } from 'react'
 
-export interface PopoverContentProps extends RadixPopover.PopoverContentProps {}
+export interface PopoverContentProps extends RadixPopover.PopoverContentProps {
+  autoSize?: boolean
+}
 
-const PopoverContent: FC<PopoverContentProps> = ({ className, ...rest }) => {
+const PopoverContent: FC<PopoverContentProps> = ({
+  className,
+  autoSize,
+  ...rest
+}) => {
   return (
     <RadixPopover.Portal>
       <RadixPopover.Content
-        className={cn('z-100', className)}
+        className={cn(
+          'z-100',
+          autoSize && 'w-[--radix-popover-trigger-width]',
+          className,
+        )}
         sideOffset={5}
         {...rest}
       />
     </RadixPopover.Portal>
   )
 }
-
 PopoverContent.displayName = 'Popover.Content'
-
 export default PopoverContent


### PR DESCRIPTION
**Resolves issue:**
- popover width setting

**Description:**
- component width was being restricted by the internal popover, making it impossible to use the component's maximum width

**Code changes:**
- fix popover width

**Breaking change:**
- [ ] Yes
- [x] No